### PR TITLE
Update .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,6 +16,8 @@ build:
     # golang: "1.17"
 
 # Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/source/conf.py
 
 # If using Sphinx, optionally build your docs in additional formats such as PDF
 # formats:


### PR DESCRIPTION
This pull request makes a small configuration update to the Read the Docs build process by specifying the Sphinx configuration file location. This change helps ensure that documentation builds use the correct settings.

* Set the Sphinx configuration file to `docs/source/conf.py` in `.readthedocs.yaml`